### PR TITLE
Selectbox component

### DIFF
--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -2,9 +2,6 @@ import { BaseComponent, BaseOptions, BaseElement} from '../base';
 import { FormioComponents } from '../components';
 import { FormioTemplate } from '../../formio.template';
 
-/**
- * The CheckBoxValidation interface.
- */
 export interface CheckBoxOptions extends BaseOptions<string> {
     defaultValue?: string,
     hideLabel?: boolean

--- a/src/components/components.ts
+++ b/src/components/components.ts
@@ -15,7 +15,8 @@ export interface FormioComponentsTemplate {
     table: string,
     panel: string,
     fieldset: string,
-    well: string
+    well: string,
+    selectboxes: string
 }
 
 export interface FormioComponentMetaData {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,6 +16,7 @@ import { Table } from './table/table';
 import { Panel } from './panel/panel';
 import { FieldSet } from './fieldset/fieldset';
 import { Well } from './well/well';
+import { SelectBox } from './selectboxes/selectboxes';
 export function RegisterComponents(template: FormioTemplate) {
     TextField(template);
     Button(template);
@@ -34,4 +35,5 @@ export function RegisterComponents(template: FormioTemplate) {
     Panel(template);
     FieldSet(template);
     Well(template);
+    SelectBox(template);
 }

--- a/src/components/selectboxes/selectboxes.spec.ts
+++ b/src/components/selectboxes/selectboxes.spec.ts
@@ -14,7 +14,37 @@ describe('SelectBoxComponent', () => {
 
     var getSettings = (overrides: {}): SelectBoxOptions => {
         let settings: SelectBoxOptions = {
-
+            input: true,
+            tableView: true,
+            label: "Select box",
+            key: "selectbox",
+            values: [
+                {
+                    value: "tea",
+                    label: "Tea"
+                },
+                {
+                    value: "tea",
+                    label: "Coffee"
+                },
+                {
+                    value: "chocolate",
+                    label: "Chocolate"
+                }
+            ],
+            inline: true,
+            protected: false,
+            persistent: true,
+            validate: {
+                required: false
+            },
+            type: "selectboxes",
+            conditional: {
+                show: null,
+                when: null,
+                eq: ""
+            },
+            customClass: "myselect"
         };
         Object.assign(settings, overrides);
         return settings;
@@ -31,7 +61,7 @@ describe('SelectBoxComponent', () => {
 
     it('Test FormioComponent for SelectBox as Custom component', () => {
         let component = getComponent({});
-        expect(component.components[0] instanceof CustomComponent).toEqual(true);
+        expect(component.components[0] instanceof SelectBoxComponent).toEqual(true);
     });
 
     it('Its type should be selectboxes', () => {
@@ -54,4 +84,67 @@ describe('SelectBoxComponent', () => {
         expect(selectbox.settings.label).toEqual("SelectBox");
     });
 
+    it('Should allow SelectBox component with required', () => {
+        let settings: SelectBoxOptions = getSettings({
+            required: true
+        });
+
+        // Create the selectbox component.
+        let selectbox = new SelectBoxComponent(this.form, settings);
+        expect(selectbox.settings.required).toEqual(true);
+    });
+
+    it('Check SelectBox option values are available or not',() => {
+        let settings: SelectBoxOptions = getSettings({
+            values: [
+                {
+                    value: "1",
+                    label: "option1"
+                },
+                {
+                    value: "2",
+                    label: "option2"
+                }
+            ]
+        });
+
+        // Create the selectbox component.
+        let selectbox = new SelectBoxComponent(this.form, settings);
+        expect(selectbox.settings.values.length).not.toEqual(0);
+    });
+
+    it('Check SelectBox options contains labels or not',() => {
+        let settings: SelectBoxOptions = getSettings({
+            values: [
+                {
+                    value: "1",
+                    label: "option1"
+                }
+            ]
+        });
+
+        // Create the selectbox component.
+        let selectbox = new SelectBoxComponent(this.form, settings);
+        expect(selectbox.settings.values[0].label).not.toEqual('');
+    });
+
+    it('Check SelectBox options appears in inline or not',() => {
+        let settings: SelectBoxOptions = getSettings({
+            inline : true
+        });
+
+        // Create the selectbox component.
+        let selectbox = new SelectBoxComponent(this.form, settings);
+        expect(selectbox.settings.inline).toEqual(true);
+    });
+
+    it('Should allow custom class',() => {
+        let settings: SelectBoxOptions = getSettings({
+            customClass : "myselect"
+        });
+
+        // Create the selectbox component.
+        let selectbox = new SelectBoxComponent(this.form, settings);
+        expect(selectbox.settings.customClass).toEqual("myselect");
+    });
 });

--- a/src/components/selectboxes/selectboxes.spec.ts
+++ b/src/components/selectboxes/selectboxes.spec.ts
@@ -1,0 +1,57 @@
+/// <reference path="../../../typings/globals/jasmine/index.d.ts" />
+import { FormGroup } from '@angular/forms';
+import { SelectBoxComponent, SelectBoxOptions } from './selectboxes';
+import { FORMIO_TEMPLATE } from '../../templates/bootstrap';
+import { RegisterComponents } from '../index';
+import { FormioComponentComponent } from '../../formio-component.component';
+import {CustomComponent} from "../custom/custom";
+
+describe('SelectBoxComponent', () => {
+    beforeEach(() => {
+        RegisterComponents(FORMIO_TEMPLATE);
+        this.form = new FormGroup({});
+    });
+
+    var getSettings = (overrides: {}): SelectBoxOptions => {
+        let settings: SelectBoxOptions = {
+
+        };
+        Object.assign(settings, overrides);
+        return settings;
+    };
+
+    let getComponent = (overrides: {}): FormioComponentComponent<string> => {
+        let settings:SelectBoxOptions = getSettings(overrides);
+        let component = new FormioComponentComponent<string>();
+        component.component = settings;
+        component.form = this.form;
+        component.ngOnInit();
+        return component;
+    };
+
+    it('Test FormioComponent for SelectBox as Custom component', () => {
+        let component = getComponent({});
+        expect(component.components[0] instanceof CustomComponent).toEqual(true);
+    });
+
+    it('Its type should be selectboxes', () => {
+        let settings: SelectBoxOptions = getSettings({
+            type: "selectboxes"
+        });
+
+        // Create the selectbox component.
+        let selectbox = new SelectBoxComponent(this.form, settings);
+        expect(selectbox.settings.type).toEqual("selectboxes");
+    });
+
+    it('Should allow label value', () => {
+        let settings: SelectBoxOptions = getSettings({
+            label: "SelectBox"
+        });
+
+        // Create the selectbox component.
+        let selectbox = new SelectBoxComponent(this.form, settings);
+        expect(selectbox.settings.label).toEqual("SelectBox");
+    });
+
+});

--- a/src/components/selectboxes/selectboxes.ts
+++ b/src/components/selectboxes/selectboxes.ts
@@ -7,7 +7,8 @@ export interface SelectBoxOptions extends BaseOptions<string> {
     type?: string,
     inline?: boolean,
     value?: string,
-    values?: Array<{}>
+    values?: Array<{}>,
+    customClass?:string
 }
 
 export class SelectBoxComponent extends BaseComponent<SelectBoxOptions> {}

--- a/src/components/selectboxes/selectboxes.ts
+++ b/src/components/selectboxes/selectboxes.ts
@@ -1,0 +1,23 @@
+import { BaseComponent, BaseOptions, BaseElement} from '../base';
+import { FormioComponents } from '../components';
+import { FormioTemplate } from '../../formio.template';
+
+export interface SelectBoxOptions extends BaseOptions<string> {
+    inputType?: string,
+    type?: string,
+    inline?: boolean,
+    value?: string,
+    values?: Array<{}>
+}
+
+export class SelectBoxComponent extends BaseComponent<SelectBoxOptions> {}
+export class SelectBoxElement extends BaseElement<SelectBoxComponent> {
+    public selected: Array<string> = [];
+}
+
+export function SelectBox(template:FormioTemplate) {
+    FormioComponents.register('selectboxes', SelectBoxComponent, SelectBoxElement, {
+        template: template.components.selectboxes
+    });
+    return SelectBoxElement;
+}

--- a/src/fixtures/forms/kitchensink.ts
+++ b/src/fixtures/forms/kitchensink.ts
@@ -673,6 +673,43 @@ export const FORM: any = {
       }
     },
     {
+      "input": true,
+      "tableView": true,
+      "label": "Select box",
+      "key": "selectbox",
+      "values": [
+        {
+          "value": "tea",
+          "label": "Tea"
+        },
+        {
+          "value": "tea",
+          "label": "Coffee"
+        },
+        {
+          "value": "chocolate",
+          "label": "Chocolate"
+        },
+        {
+          "value": "ice-cream",
+          "label": "Ice-Cream"
+        }
+      ],
+      "inline": true,
+      "protected": false,
+      "persistent": true,
+      "validate": {
+        "required": false
+      },
+      "type": "selectboxes",
+      "conditional": {
+        "show": null,
+        "when": null,
+        "eq": ""
+      },
+      "customClass": "myselect"
+    },
+    {
       "input": false,
       "title": "Panel",
       "theme": "primary",

--- a/src/templates/bootstrap.ts
+++ b/src/templates/bootstrap.ts
@@ -24,6 +24,7 @@ export const FORMIO_TEMPLATE: FormioTemplate = {
         table: require('./bootstrap/components/table.html'),
         panel: require('./bootstrap/components/panel.html'),
         fieldset: require('./bootstrap/components/fieldset.html'),
-        well: require('./bootstrap/components/well.html')
+        well: require('./bootstrap/components/well.html'),
+        selectboxes: require('./bootstrap/components/selectboxes.html')
     }
 };

--- a/src/templates/bootstrap/components/selectboxes.html
+++ b/src/templates/bootstrap/components/selectboxes.html
@@ -1,0 +1,11 @@
+<div [formGroup]="form" class="form-group {{component.settings.customClass}}" [ngClass]="{'required': (component.settings.validate && component.settings.validate.required)}">
+    <label *ngIf="component.label" [attr.for]="component.settings.key" class="control-label">{{ component.label }}</label>
+    <div class="input-group">
+        <div *ngFor="let option of component.settings.values; let i = index;" [ngClass]="{'checkbox-inline': component.settings.inline==true,'checkbox': component.settings.inline==false}">
+            <label [attr.for]="component.settings.key">
+                <input type="checkbox" [checked]="selected[option.value] ? option.value : '' " (change)="selected[option.value] ? (selected[option.value] = false) : (selected[option.value] = true)" [formControl]="component.control"  name="{{component.settings.key}}" value="{{option.value}}"/>
+                {{ option.label }}
+            </label>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Implementation of SelectBox component.
Added required template and typescript code to render selectbox component.
Implemented test cases on following scenarios:
Test formio component for select box.
Its type should be selectboxes.
Should allow label.
Should allow custom class.
Should allow select box component with required.
Check select box option values are available or not.
Check select box options contains labels or not.
Check select boxes appears in inline or not.