### PR TITLE
Implementation of address component.

### DIFF
--- a/src/components/address/address.spec.ts
+++ b/src/components/address/address.spec.ts
@@ -1,0 +1,91 @@
+import { FormGroup } from '@angular/forms';
+import { FormioComponentComponent } from '../../formio-component.component';
+import { AddressComponent, AddressOptions } from './address';
+import { FORMIO_TEMPLATE } from '../../templates/bootstrap';
+import { RegisterComponents } from '../index';
+
+describe('AddressComponent', () => {
+    beforeEach(() => {
+        RegisterComponents(FORMIO_TEMPLATE);
+        this.form = new FormGroup({});
+    });
+
+    var getSettings = (overrides: {}): AddressOptions => {
+        let settings: AddressOptions = {
+            input: true,
+            tableView: true,
+            label: "Address",
+            key: "address",
+            placeholder: "Enter Address",
+            multiple: false,
+            protected: false,
+            unique: false,
+            persistent: true,
+            validate: {
+                required: true
+            },
+            type: "address",
+            conditional: {
+                show: null,
+                when: null,
+                eq: ""
+            },
+            customClass: "myclass"
+        };
+        Object.assign(settings, overrides);
+        return settings;
+    };
+
+    let getComponent = (overrides: {}): FormioComponentComponent<string> => {
+        let settings:AddressOptions = getSettings(overrides);
+        let component = new FormioComponentComponent<string>();
+        component.component = settings;
+        component.form = this.form;
+        component.ngOnInit();
+        return component;
+    };
+    it('Test FormioComponent for Address', () => {
+        let component = getComponent({});
+        expect(component.components[0] instanceof AddressComponent).toEqual(true);
+    });
+
+    it('Type should be Address', () => {
+        let settings: AddressOptions = getSettings({
+            type: "address"
+        });
+
+        // Create the address component.
+        let address = new AddressComponent(this.form, settings);
+        expect(address.settings.type).toEqual("address");
+    });
+
+    it('Should allow label', () => {
+        let settings: AddressOptions = getSettings({
+            label: "Address"
+        });
+
+        // Create the address component.
+        let address = new AddressComponent(this.form, settings);
+        expect(address.settings.label).toEqual("Address");
+    });
+
+    it('Should allow placeholder', () => {
+        let settings: AddressOptions = getSettings({
+            placeholder: "Enter address"
+        });
+
+        // Create the address component.
+        let address = new AddressComponent(this.form, settings);
+        expect(address.settings.placeholder).toEqual("Enter address");
+    });
+
+    it('Should allow customClass', () => {
+        let settings: AddressOptions = getSettings({
+            customClass: "myclass"
+        });
+
+        // Create the address component.
+        let address = new AddressComponent(this.form, settings);
+        expect(address.settings.customClass).toEqual("myclass");
+    });
+});

--- a/src/components/address/address.ts
+++ b/src/components/address/address.ts
@@ -1,0 +1,52 @@
+import { BaseComponent, BaseOptions, BaseElement} from '../base';
+import { FormioComponents } from '../components';
+import { FormioTemplate } from '../../formio.template';
+import { CORE_DIRECTIVES, FORM_DIRECTIVES, NgClass } from '@angular/common';
+import { SELECT_DIRECTIVES } from '../../../node_modules/ng2-select/ng2-select';
+var Formio = require('formiojs');
+import 'style!ng2-select/components/css/ng2-select.css';
+
+export interface AddressOptions extends BaseOptions<string> {
+    placeholder?: string,
+    customClass?: string
+}
+
+interface IdTextPair{
+    id: string;
+    text: string;
+}
+
+export class AddressComponent extends BaseComponent<AddressOptions> {
+    allowMultiple(): boolean{
+        return false;
+    }
+}
+
+export class AddressElement extends BaseElement<AddressComponent> {
+    private value:any = {};
+    public refreshValue(value:any):void
+    {
+        this.value = value;
+    }
+    public selectedItem: Array<any> = [];
+    public selectedData(value:any):void
+    {
+        let this1 = this;
+        let selectItems: IdTextPair[] = [];
+        let url: string = "https://maps.googleapis.com/maps/api/geocode/json?address="+value+"&sensor=false";
+        Formio.request(url, 'POST', {}, {}).then(function(response: any){
+            response.results.forEach((item: any) => {
+                selectItems.push({id: item.formatted_address, text: item.formatted_address});
+            });
+            this1.selectedItem = selectItems.slice(0);
+        });
+    }
+}
+
+export function Address(template:FormioTemplate) {
+    FormioComponents.register('address', AddressComponent, AddressElement, {
+        template: template.components.address,
+        directives: [SELECT_DIRECTIVES, NgClass, CORE_DIRECTIVES, FORM_DIRECTIVES]
+    });
+    return AddressElement;
+}

--- a/src/components/components.ts
+++ b/src/components/components.ts
@@ -21,7 +21,8 @@ export interface FormioComponentsTemplate {
     htmlelement: string,
     currency: string,
     select: string,
-    survey: string
+    survey: string,
+    address: string
 }
 
 export interface FormioComponentMetaData {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,6 +22,7 @@ import { Content } from './content/content';
 import { HtmlElement } from './htmlelement/htmlelement';
 import { Select } from './select/select';
 import { Survey } from './survey/survey';
+import {Address} from './address/address';
 export function RegisterComponents(template: FormioTemplate) {
     TextField(template);
     Button(template);
@@ -46,4 +47,5 @@ export function RegisterComponents(template: FormioTemplate) {
     HtmlElement(template);
     Select(template);
     Survey(template);
+    Address(template);
 }

--- a/src/fixtures/forms/kitchensink.ts
+++ b/src/fixtures/forms/kitchensink.ts
@@ -947,6 +947,27 @@ export const FORM: any = {
         }
     },
     {
+    "input": true,
+    "tableView": true,
+    "label": "Address",
+    "key": "address",
+    "placeholder": "Enter Address",
+    "multiple": false,
+    "protected": false,
+    "unique": false,
+    "persistent": true,
+    "validate": {
+      "required": true
+    },
+    "type": "address",
+    "conditional": {
+      "show": null,
+      "when": null,
+      "eq": ""
+      },
+    "customClass": "myclass"
+    },
+    {
       "input": true,
       "tableView": true,
       "key": "name",

--- a/src/templates/bootstrap.ts
+++ b/src/templates/bootstrap.ts
@@ -30,6 +30,7 @@ export const FORMIO_TEMPLATE: FormioTemplate = {
         htmlelement: require('./bootstrap/components/htmlelement.html'),
         currency: require('./bootstrap/components/currency.html'),
         select: require('./bootstrap/components/select.html'),
-        survey: require('./bootstrap/components/survey.html')
+        survey: require('./bootstrap/components/survey.html'),
+        address: require('./bootstrap/components/address.html')
     }
 };

--- a/src/templates/bootstrap/components/address.html
+++ b/src/templates/bootstrap/components/address.html
@@ -1,0 +1,9 @@
+<div class="{{component.settings.customClass}}" [ngClass]="{'required': (component.settings.validate && component.settings.validate.required)}">
+    <label *ngIf="component.label" [attr.for]="component.settings.key" class="control-label"><h3>{{ component.label }}</h3></label>
+    <ng-select [items]="selectedItem"
+               (data)="refreshValue($event)"
+               [multiple]="component.settings.multiple"
+               placeholder="{{component.settings.placeholder}}"
+               (typed)="selectedData($event)">
+    </ng-select>
+</div>


### PR DESCRIPTION
Added required template and typescript code to render address component.
Used ng2-select library to implement address component.
Implemented test cases on following scenarios:
Test formio component for address.
Its type should be address.
Should allow label value.
Should allow placeholder.
Should allow custom class.