### PR TITLE
Fix zone.js version dependency for NG 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ng2-bootstrap": "^1.1.16",
     "ng2-select": "^1.1.2",
     "rxjs": "^5.0.1",
-    "zone.js": "^0.6.26"
+    "zone.js": "^0.7.4"
   },
   "devDependencies": {
     "@angular/platform-browser": "^2.4.0",


### PR DESCRIPTION
The version should be 0.7.4:
https://angular.io/docs/js/latest/quickstart.html
```json
"rxjs": "5.0.1",
"zone.js": "^0.7.4"
```
Otherwise it spills errors when installing locally.

Thanks!