### PR TITLE
Fix version @types/jasmine to fix compiling error

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@angular/router": "^3.4.8",
     "@types/chai": "^3.4.34",
     "@types/core-js": "^0.9.35",
-    "@types/jasmine": "^2.5.40",
+    "@types/jasmine": "2.5.41",
     "@types/node": "^6.0.58",
     "angular2-template-loader": "^0.4.0",
     "awesome-typescript-loader": "^2.2.4",


### PR DESCRIPTION
`npm test` returns an error when `@types/jasmine` version > 2.5.41

	webpack: Compiled successfully.
	webpack: Compiling...

	ERROR in [default] /home/gsm/Desktop/form.io/ng2-formio/node_modules/@types/jasmine/index.d.ts:39:37 
	A parameter initializer is only allowed in a function or constructor implementation.

	ERROR in [default] /home/gsm/Desktop/form.io/ng2-formio/node_modules/@types/jasmine/index.d.ts:39:45 
	Cannot find name 'keyof'.

	ERROR in [default] /home/gsm/Desktop/form.io/ng2-formio/node_modules/@types/jasmine/index.d.ts:39:51 
	'=' expected.

	ERROR in [default] /home/gsm/Desktop/form.io/ng2-formio/node_modules/@types/jasmine/index.d.ts:41:45 
	A parameter initializer is only allowed in a function or constructor implementation.

	ERROR in [default] /home/gsm/Desktop/form.io/ng2-formio/node_modules/@types/jasmine/index.d.ts:41:55 
	Cannot find name 'keyof'.

	ERROR in [default] /home/gsm/Desktop/form.io/ng2-formio/node_modules/@types/jasmine/index.d.ts:41:61 
	'=' expected.
	webpack: Failed to compile.

